### PR TITLE
fix: aioredis syntax in unit tests

### DIFF
--- a/.github/workflows/test-comet.yml
+++ b/.github/workflows/test-comet.yml
@@ -14,14 +14,6 @@ jobs:
     
     services:
       mysql:
-        #image: mariadb:10.4
-        #env:
-          #MYSQL_USER: vish_user
-          #MYSQL_PASSWORD: vish_pass
-          #MYSQL_ROOT_PASSWORD: root
-        #ports:
-        #- 3306/3306
-        #options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
         image: mariadb:10.4
         env:
           MYSQL_ROOT_PASSWORD: symfony
@@ -32,7 +24,12 @@ jobs:
       redis:
         image: redis
         ports:
-        - 6379/tcp
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     
     steps:
       - name: checkout
@@ -48,13 +45,13 @@ jobs:
         run: |
           sudo apt-get -y install libevent-dev
           sudo apt-get -y install libboost-test-dev
-          sudo apt-get -y install gcc-8
-          sudo apt-get -y install g++-8
+          sudo apt-get -y install findutils
+          sudo apt-get -y install gcc
         shell: bash
       - name: setup-python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: before-install
         uses: BSFishy/pip-action@v1
         with:
@@ -68,8 +65,10 @@ jobs:
             locust
             future
             aiohttp
+            flask
+            pytest-localserver
       - name: install
-        run: python -m pip install .
+        run: pip install --use-deprecated=legacy-resolver .
         shell: bash
       - name: before-script
         env:
@@ -80,7 +79,10 @@ jobs:
         shell: bash
       - name: script
         env:
-          PATH: "/usr/lib/ccache:$HOME/miniconda/bin:$PATH"
+          REDIS_HOST: 0.0.0.0
+          REDIS_PORT: 6379
+        #env:
+        #  PATH: "/usr/lib/ccache:$HOME/miniconda/bin:$PATH"
         run: |
           black comet/broker.py
           black --check .
@@ -92,6 +94,3 @@ jobs:
           CAPUT_SKYFIELD_PATH=skyfield_data ./kotetest.sh
           ccache -s || true
         shell: bash
-          
-       
-       

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aioredis>=2.0
 async_lru
 redis
 requests
-sanic>=20.6.0 ; python_version >= '3.6'
+sanic<=22.6.0 ; python_version >= '3.6'
 multidict>=4.6.1
 caput @ git+https://github.com/radiocosmology/caput.git
 mmh3

--- a/tests/kotetest.sh
+++ b/tests/kotetest.sh
@@ -10,6 +10,7 @@ make dataset_broker_producer dataset_broker_producer2 dataset_broker_consumer
 
 more /proc/cpuinfo | grep flags
 
+pip install flask pytest-localserver
 cd ../tests
 export PYTHONPATH=../python:$PYTHONPATH
 pytest -x test_dataset_broker.py

--- a/tests/test_redis_cond_var.py
+++ b/tests/test_redis_cond_var.py
@@ -1,3 +1,4 @@
+import os
 import asyncio
 import aioredis
 import pytest
@@ -9,25 +10,26 @@ import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
+REDIS_PORT = os.environ.get("REDIS_PORT", 6379)
+REDIS_HOST = os.environ.get("REDIS_HOST", "0.0.0.0")
+REDIS_URL = "redis://{0}:{1}".format(REDIS_HOST, REDIS_PORT)
+
 
 @pytest.mark.asyncio
 async def test_cond_variable():
     """Test that a single condition variable works as expected."""
-    redis = await aioredis.create_pool(
-        ("127.0.0.1", 6379), encoding="utf-8", maxsize=30
-    )
-
+    redis = aioredis.from_url(REDIS_URL, encoding="utf-8", max_connections=30)
     lock = await Lock.create(redis, "testlock")
     cond = await Condition.create(lock, "testcond")
 
-    await redis.execute("del", "testkey")
+    await redis.execute_command("del", "testkey")
 
     # Create a task that waits on the variable and reads a key. This key won't
     # exist until after the task has been notified
     async def task():
         r = await cond.acquire()
         await cond.wait()
-        assert await r.execute("get", "testkey") == "1"
+        assert await r.execute_command("get", "testkey") == b"1"
         await cond.release()
 
     # Create tasks
@@ -40,7 +42,7 @@ async def test_cond_variable():
 
     # Set the key and notify
     r = await cond.acquire()
-    await r.execute("set", "testkey", 1)
+    await r.execute_command("set", "testkey", 1)
     await cond.notify_all()
     await cond.release()
 
@@ -52,28 +54,25 @@ async def test_cond_variable():
         assert t.done()
         assert t.exception() is None
 
-    redis.close()
-    await redis.wait_closed()
+    await redis.close()
 
 
 @pytest.mark.asyncio
 async def test_cond_context_manager():
     """Test that a single condition variable works as expected."""
-    redis = await aioredis.create_pool(
-        ("127.0.0.1", 6379), encoding="utf-8", maxsize=30
-    )
 
+    redis = aioredis.from_url(REDIS_URL, encoding="utf-8")
     lock = await Lock.create(redis, "testlock")
     cond = await Condition.create(lock, "testcond")
 
-    await redis.execute("del", "testkey")
+    await redis.execute_command("del", "testkey")
 
     # Create a task that waits on the variable and reads a key. This key won't
     # exist until after the task has been notified
     async def task():
         async with cond as r:
             await cond.wait()
-            assert await r.execute("get", "testkey") == "1"
+            assert await r.get("testkey") == b"1"
 
     # Create tasks
     tasks = [asyncio.create_task(task()) for i in range(20)]
@@ -85,7 +84,7 @@ async def test_cond_context_manager():
 
     # Set the key and notify
     async with cond as r:
-        await r.execute("set", "testkey", 1)
+        await r.set("testkey", 1)
         await cond.notify_all()
 
     # Give some time for tasks to finish
@@ -96,8 +95,7 @@ async def test_cond_context_manager():
         assert t.exception() is None
         assert t.done()
 
-    redis.close()
-    await redis.wait_closed()
+    await redis.close()
 
 
 @pytest.mark.asyncio
@@ -105,26 +103,23 @@ async def test_cond_two_variables():
     """Similar to the above test, but check that two condition variables can
     work at the same time."""
 
-    redis = await aioredis.create_pool(
-        ("127.0.0.1", 6379), encoding="utf-8", maxsize=45
-    )
-
+    redis = aioredis.from_url(REDIS_URL, encoding="utf-8")
     lock = await Lock.create(redis, "testlock")
     cond_a = await Condition.create(lock, "testcond_a")
     cond_b = await Condition.create(lock, "testcond_b")
 
-    redis.execute("del", "testkey_a")
-    redis.execute("del", "testkey_b")
+    await redis.execute_command("del", "testkey_a")
+    await redis.execute_command("del", "testkey_b")
 
     async def task_a():
         async with cond_a as r:
             await cond_a.wait()
-            assert await r.execute("get", "testkey_a") == "1"
+            assert await r.get("testkey_a") == b"1"
 
     async def task_b():
         async with cond_b as r:
             await cond_b.wait()
-            assert await r.execute("get", "testkey_b") == "1"
+            assert await r.get("testkey_b") == b"1"
 
     tasks_a = [asyncio.create_task(task_a()) for i in range(20)]
     tasks_b = [asyncio.create_task(task_b()) for i in range(20)]
@@ -135,7 +130,7 @@ async def test_cond_two_variables():
         assert not t.done()
 
     async with cond_a as r:
-        await r.execute("set", "testkey_a", 1)
+        await r.set("testkey_a", 1)
         await cond_a.notify_all()
 
     # Wait for task A's to finish
@@ -146,7 +141,7 @@ async def test_cond_two_variables():
         assert t.exception() is None
 
     async with cond_b as r:
-        await r.execute("set", "testkey_b", 1)
+        await r.set("testkey_b", 1)
         await cond_b.notify_all()
 
     # Wait for task B's to finish
@@ -156,5 +151,4 @@ async def test_cond_two_variables():
         assert t.done()
         assert t.exception() is None
 
-    redis.close()
-    await redis.wait_closed()
+    await redis.close()

--- a/tests/test_redis_lock.py
+++ b/tests/test_redis_lock.py
@@ -1,3 +1,4 @@
+import os
 import asyncio
 import aioredis
 import pytest
@@ -8,19 +9,23 @@ logging.basicConfig(level=logging.DEBUG)
 
 from comet.redis_async_locks import Lock
 
+REDIS_PORT = os.environ.get("REDIS_PORT", 6379)
+REDIS_HOST = os.environ.get("REDIS_HOST", "0.0.0.0")
+REDIS_URL = "redis://{0}:{1}".format(REDIS_HOST, REDIS_PORT)
+
 
 @pytest.mark.asyncio
 async def test_lock():
     """Test that the locks work when called directly."""
 
-    redis = await aioredis.create_pool(("127.0.0.1", 6379), encoding="utf-8")
+    redis = aioredis.from_url(REDIS_URL, encoding="utf-8")
     lock = await Lock.create(redis, "test1")
 
     task1_end = False
 
     async def task1():
         r = await lock.acquire()
-        await r.execute("lpush", "testlist1", 1)
+        await r.lpush("testlist1", 1)
         # Block until told to end
         while not task1_end:
             await asyncio.sleep(0.05)
@@ -28,7 +33,7 @@ async def test_lock():
 
     async def task2():
         r = await lock.acquire()
-        assert await r.execute("del", "testlist1") == 1
+        assert await r.execute_command("del", "testlist1") == 1
 
     # Create and start up task1
     task1_future = asyncio.create_task(task1())
@@ -48,28 +53,30 @@ async def test_lock():
     assert task1_future.done()
     assert task2_future.done()
 
-    redis.close()
-    await redis.wait_closed()
+    await redis.close()
+
+
+#    await redis.wait_closed()
 
 
 @pytest.mark.asyncio
 async def test_lock_manager():
     """Test that the locks work when used as a context manager."""
 
-    redis = await aioredis.create_pool(("127.0.0.1", 6379), encoding="utf-8")
+    redis = aioredis.from_url(REDIS_URL, encoding="utf-8")
     lock = await Lock.create(redis, "test1")
 
     task1_end = False
 
     async def task1():
         async with lock as r:
-            await r.execute("lpush", "testlist1", 1)
+            await r.lpush("testlist1", 1)
             while not task1_end:
                 await asyncio.sleep(0.05)
 
     async def task2():
         async with lock as r:
-            assert await r.execute("del", "testlist1") == 1
+            assert await r.execute_command("del", "testlist1") == 1
 
     # Create and start up task1
     task1_future = asyncio.create_task(task1())
@@ -95,10 +102,12 @@ async def test_lock_manager():
 
     # Test that the lock entries are removed when it is closed
     await lock.close()
-    assert not await redis.execute("exists", lock.lockname)
+    assert not await redis.execute_command("exists", lock.lockname)
 
-    redis.close()
-    await redis.wait_closed()
+    await redis.close()
+
+
+#    await redis.wait_closed()
 
 
 @pytest.mark.asyncio
@@ -110,29 +119,27 @@ async def test_large():
 
     # Deliberately set a number of simultaneous connections much smaller than
     # the number of tasks to test connection starvation
-    redis = await aioredis.create_pool(("127.0.0.1", 6379), encoding="utf-8", maxsize=1)
-
+    redis = aioredis.from_url(REDIS_URL, encoding="utf-8")
     # Create the lock and reset the test value
     lock = await Lock.create(redis, key)
-    await redis.execute("del", key)
+    await redis.execute_command("del", key)
 
     # Perform a non-atomic increment of a variable in redis
     # This is obviously stupid except for testing the locking
     async def task():
         # with await redis as r:  ## Use this to see how badly the test fails
         async with lock as r:
-            val = await r.execute("get", key)
+            val = await r.get(key)
             val = int(val) if val is not None else 0
             # Deliberately sleep to give other tasks a chance to break things
             # (if the lock wasn't here)
             await asyncio.sleep(0.01)
-            await r.execute("set", key, val + 1)
+            await r.set(key, val + 1)
 
     tasks = [task() for _ in range(ntask)]
     await asyncio.gather(*tasks)
 
-    val = await redis.execute("get", key)
+    val = await redis.get(key)
     assert int(val) == ntask
 
-    redis.close()
-    await redis.wait_closed()
+    await redis.close()


### PR DESCRIPTION
@VishwangiShah312 I've squashed all my commits into this one, and reset your branch to where it was before I started messing with it. These changes now have the tests passing in github actions.

fix: redis_async_locks for aioredis v2

ci: use deprecated legacy resolver

ci: remove cache_exceptions from alru_cache (no longer supported)

ci: add redis healthcheck

ci: install requirements for kotekan test